### PR TITLE
prevens use of activation key during the build

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -108,6 +108,9 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+        # prevent this build from using the activation key - otherwise buildah tries to enable the rhel8 repos, while only the ubi8 repos have been prefetched (and as this is a hermetic build - that fails)
+      - name: ACTIVATION_KEY
+        value: "dont-need-no-key"
       runAfter:
       - prefetch-dependencies
       taskRef:

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -109,6 +109,9 @@ spec:
           value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
         - name: CACHI2_ARTIFACT
           value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        # prevent this build from using the activation key - otherwise buildah tries to enable the rhel8 repos, while only the ubi8 repos have been prefetched (and as this is a hermetic build - that fails)
+        - name: ACTIVATION_KEY
+          value: "dont-need-no-key"
     - name: build-source-image
       taskRef:
         resolver: bundles

--- a/bundle-hack/update_bundle.sh
+++ b/bundle-hack/update_bundle.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export MARIN3R_OPERATOR_IMAGE_PULLSPEC="quay.io/redhat-user-workloads/api-management-tenant/marin3r/marin3r-operator@sha256:aa395edded8dde4a38e1033fa47e2fad6fa0bebc1aa0889d5da47afcb8f34267"
+export MARIN3R_OPERATOR_IMAGE_PULLSPEC="quay.io/redhat-user-workloads/3scale-prod-tenant/marin3r/marin3r-operator@sha256:aa395edded8dde4a38e1033fa47e2fad6fa0bebc1aa0889d5da47afcb8f34267"
 
 export CSV_FILE=/manifests/marin3r.clusterserviceversion.yaml
 


### PR DESCRIPTION
(by using a non-existent key name)